### PR TITLE
Explicitly describe `Account` inheritance in `Plutus` models

### DIFF
--- a/app/models/plutus/asset.rb
+++ b/app/models/plutus/asset.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Asset Assets
   #
   # @author Michael Bulat
-  class Asset < Account
+  class Asset < Plutus::Account
 
     self.normal_credit_balance = false
 

--- a/app/models/plutus/equity.rb
+++ b/app/models/plutus/equity.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Equity_(finance) Equity
   #
   # @author Michael Bulat
-  class Equity < Account
+  class Equity < Plutus::Account
 
     self.normal_credit_balance = true
 

--- a/app/models/plutus/expense.rb
+++ b/app/models/plutus/expense.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Expense Expenses
   #
   # @author Michael Bulat
-  class Expense < Account
+  class Expense < Plutus::Account
 
     self.normal_credit_balance = false
 

--- a/app/models/plutus/liability.rb
+++ b/app/models/plutus/liability.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Liability_(financial_accounting) Liability
   #
   # @author Michael Bulat
-  class Liability < Account
+  class Liability < Plutus::Account
 
     self.normal_credit_balance = true
 

--- a/app/models/plutus/revenue.rb
+++ b/app/models/plutus/revenue.rb
@@ -7,7 +7,7 @@ module Plutus
   # @see http://en.wikipedia.org/wiki/Revenue Revenue
   #
   # @author Michael Bulat
-  class Revenue < Account
+  class Revenue < Plutus::Account
 
     self.normal_credit_balance = true
 


### PR DESCRIPTION
Travis reported an error when running tests for an application we've developed

```bash
$ bundle exec rake db:create db:test:prepare
Created database '<redacted>_test'
rake aborted!
NoMethodError: undefined method `normal_credit_balance=' for #<Class:0x00000000093ada78>
/home/travis/build/bloom-solutions/bloom_trade/vendor/bundle/ruby/2.5.0/gems/activerecord-5.1.6/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/home/travis/build/bloom-solutions/bloom_trade/vendor/bundle/ruby/2.5.0/gems/attr_encrypted-3.1.0/lib/attr_encrypted.rb:306:in `method_missing'
/home/travis/build/bloom-solutions/bloom_trade/vendor/bundle/ruby/2.5.0/gems/attr_encrypted-3.1.0/lib/attr_encrypted/adapters/active_record.rb:131:in `method_missing_with_attr_encrypted'
/home/travis/build/bloom-solutions/bloom_trade/vendor/bundle/ruby/2.5.0/gems/plutus-0.13/app/models/plutus/expense.rb:12:in `<class:Expense>'
/home/travis/build/bloom-solutions/bloom_trade/vendor/bundle/ruby/2.5.0/gems/plutus-0.13/app/models/plutus/expense.rb:10:in `<module:Plutus>'
/home/travis/build/bloom-solutions/bloom_trade/vendor/bundle/ruby/2.5.0/gems/plutus-0.13/app/models/plutus/expense.rb:1:in `<top (required)>'
```

A hypothesis was because the parent app had an `Account` model as well, and it's colliding with the usage of `Plutus::Account` when it's being inherited by `Expense`, `Liability`, etc.

After making this change, the tests have passed for the application